### PR TITLE
[인섭] 2024년 11월 2주차 풀이

### DIFF
--- a/BOJ/11726. 2xn 타일링/insub2004_241109
+++ b/BOJ/11726. 2xn 타일링/insub2004_241109
@@ -1,0 +1,28 @@
+package BOJ.DP.이곱하기n타일링_11726.insub2004_241110;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+public class Main {
+    // 점화식
+    // 규칙이 있었다.
+    // d(n) = d(n-2) + d(n-1)
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+
+        int[] array = new int[n+1];
+        array[1] = 1;
+        if (n > 1) {
+            array[2] = 2;  // n이 1보다 클 때만 array[2] 초기화 (ArrayIndexOutOfBounds)
+        }
+
+        for (int i = 3; i <= n; i++) {
+            array[i] = (array[i-2] + array[i-1]) % 10007;   // int형의 최대 범위를 벗어날 수 있기 때문에 마지막에 모듈러 연산을 하는게 아니라
+        }                                                   // 매 단계마다 모듈러 연산을 해줘야한다.
+
+        System.out.println(array[n]);
+
+    }
+}

--- a/BOJ/11727. 2xn 타일링 2/insub2004_241110
+++ b/BOJ/11727. 2xn 타일링 2/insub2004_241110
@@ -1,0 +1,24 @@
+package BOJ.DP.이곱하기n타일링2_11727.insub2004_241110;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+public class Main {
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+
+        int[] array = new int[n+1];
+        array[1] = 1;
+        if (n > 1) {
+            array[2] = 3;   // (ArrayIndexOutOfBounds)
+        }
+
+        for (int i = 3; i <= n; i++) {  // n까지 반복
+            array[i] = (array[i-1] + array[i-2]*2) % 10007;
+        }
+
+        System.out.println(array[n]);
+    }
+}

--- a/BOJ/1463. 1로 만들기/insub2004_241108
+++ b/BOJ/1463. 1로 만들기/insub2004_241108
@@ -1,0 +1,37 @@
+package BOJ.DP.일로만들기_1463.insub2004_241108;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+public class Main {
+
+    private static int[] array = new int[1000003];
+
+    public static void main(String[] args) throws Exception {
+        array[2] = 1;
+        array[3] = 1;
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int input = Integer.parseInt(br.readLine());
+
+        for (int i = 4; i < array.length; i++) {
+            int a = Integer.MAX_VALUE;  // 만약, i를 3으로 나눌 수 있는경우 -> 3으로 나눈 값을 저장할 변수
+            int b = Integer.MAX_VALUE;  // 만약, i를 2으로 나눌 수 있는경우 -> 2으로 나눈 값을 저장할 변수
+            int c = Integer.MAX_VALUE;  // i에서 1을 뺀 값을 저장할 변수
+
+            if (i % 3 == 0) {
+                a = array[i / 3];       // array[i/3]에는 n(i)을 1로 만들때의 최솟값이 있음
+            }
+            if (i % 2 == 0) {
+                b = array[i / 2];       // array[i/2]에는 n(i)을 1로 만들때의 최솟값이 있음
+            }
+            c = array[i - 1];           // array[i-1]에는 n(i)을 1로 만들때의 최솟값이 있음
+
+            array[i] = Math.min(a,Math.min(b,c)) + 1;
+        }
+
+        System.out.println(array[input]);
+
+    }
+
+}


### PR DESCRIPTION
1463. 1로 만들기
방식 3가지는 아래 기호 참고
a. 3으로 나누기
b. 2로 나누기
c. 1빼기
- int 배열을 하나 만든다. 길이는 1000003 (입력 될 최대 정수 값이 10^6이라서)
- 배열의 인덱스를 입력받은 N이라고 생각, 인덱스의 값은 N이(i가) 1로 갈 수 있는 최소 횟수를 저장
- 배열의 2번째 : b --> 1번 (최소 횟수)
- 배열의 3번째 : a --> 1번 (최소 횟수)
- 반복문을 돌면서 a,b가 가능하다면 배열의[i]번째의 값을 각각 저장하고 c의 경우는 무조건 가능하니깐 저장
- 그 중에서 제일 작은 숫자를 찾아서 거기에 +1을 해주면 된다. (+1하는 이유는 바로 윗줄의 a,b,c 방식을 한 행위가 연산 1번이니깐)
- 결국엔 [i] = 배열[a,b,c] 중 제일 최솟값 + 1


11726. 2xn 타일링
11727. 2xn 타일링 2
- 이 문제들은 잘 몰라서 정답을 먼저 보고 풀었다.
- 규칙을 찾고 점화식을 세워서 풀었는데 그림으로 설명하는게 나을거 같아서 블로그에 정리한 후 링크 올리겠다.