### PR TITLE
[미정] 2024년 11월 3주차 풀이

### DIFF
--- a/BOJ/10844. 쉬운 계단 수/qaw302_241115.java
+++ b/BOJ/10844. 쉬운 계단 수/qaw302_241115.java
@@ -1,0 +1,69 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.IOException;
+
+/**
+ * 소요 시간 : 1시간 18분 (정답 참고 함)
+ */
+public class Main
+{
+    public static void main(String args[]) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+        int[][] dp = new int[n+1][10];
+
+        for (int i=1; i<dp[1].length; i++) {
+            dp[1][i] = 1;
+        }
+        
+        for (int i=2; i<=n; i++) {
+            dp[i][0] = dp[i-1][1];
+            dp[i][9] = dp[i-1][8];
+            for (int j=1; j<9; j++) {
+                dp[i][j] = (dp[i-1][j-1] + dp[i-1][j+1]) % 1000000000;
+            }
+        }
+
+        long sum = 0;
+        for (int i=0; i<=9; i++) {
+            sum += dp[n][i];
+        }
+        
+
+        System.out.println(sum%1000000000);
+        br.close();
+
+
+
+        /** 아래는 다른 사람 코드를 보고 수정한 코드
+         * - 모듈러 연산할 때 나누는 값을 변수로 지정해둠
+         * - sum의 타입을 long에서 int로 변경 후 MOD로 모듈러 연산
+         */ 
+        // int MOD = 1000000000;
+        // BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        // int n = Integer.parseInt(br.readLine());
+        // int[][] dp = new int[n+1][10];
+
+        // for (int i=1; i<dp[1].length; i++) {
+        //     dp[1][i] = 1;
+        // }
+        
+        // for (int i=2; i<=n; i++) {
+        //     dp[i][0] = dp[i-1][1];
+        //     dp[i][9] = dp[i-1][8];
+        //     for (int j=1; j<9; j++) {
+        //         dp[i][j] = (dp[i-1][j-1] + dp[i-1][j+1]) % MOD;
+        //     }
+        // }
+
+        // int sum = 0;
+        // for (int i=0; i<=9; i++) {
+        //     sum += dp[n][i] % MOD;
+        // }
+        
+
+        // System.out.println(sum%MOD);
+        // br.close();
+        
+    }
+}

--- a/BOJ/11057. 오르막 수/qaw302_241116.java
+++ b/BOJ/11057. 오르막 수/qaw302_241116.java
@@ -1,0 +1,32 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.IOException;
+
+/**
+ * 소요 시간 : 1시간 12분
+ */
+public class Main {
+    public static final int MOD = 10007;
+    public static void main(String args[]) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+
+        int[][] dp = new int[n+1][10];
+        dp[0][0] = 1;
+
+        for (int i=1; i<=n; i++) {
+            dp[i][0] = 1;
+            for (int j=1; j<dp[i].length; j++) {
+                dp[i][j] =(dp[i-1][j] + dp[i][j-1]) % MOD;
+            }
+        }
+
+        int sum = 0;
+        for (int i=0; i<dp[n].length; i++) {
+            sum += dp[n][i] % MOD;
+        }
+
+        System.out.println(sum % MOD);
+        br.close();
+    }
+}

--- a/BOJ/9095. 1,2,3 더하기/qaw302_241113.java
+++ b/BOJ/9095. 1,2,3 더하기/qaw302_241113.java
@@ -1,0 +1,31 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.IOException;
+
+
+public class Main {
+    public static void main(String args[]) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+
+        int t = Integer.parseInt(br.readLine());
+        for (int i=0; i<t; i++) {
+            int n = Integer.parseInt(br.readLine());
+            int[] cnts = new int[n+1];
+            cnts[0] = 1;
+            cnts[1] = 1;
+
+            if (n > 1) {
+                cnts[2] = 2;
+            }
+            for (int j=3; j<=n; j++) {
+                cnts[j] = cnts[j-1] + cnts[j-2] + cnts[j-3];
+            }
+            sb.append(cnts[n]);
+            sb.append("\n");
+        }
+
+        br.close();
+        System.out.print(sb.toString());
+    }
+}

--- a/BOJ/9095. 1,2,3 더하기/qaw302_241113.java
+++ b/BOJ/9095. 1,2,3 더하기/qaw302_241113.java
@@ -2,7 +2,9 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.io.IOException;
 
-
+/**
+ * 소요시간 : 44분
+ */
 public class Main {
     public static void main(String args[]) throws IOException {
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));


### PR DESCRIPTION
## BOJ - 9095 : 1, 2, 3 더하기

> [key]
> - 점화식 찾기
> - dp[n] = dp[n-1] + dp[n-2] + dp[n-3]

직접 1부터 n까지 적어나가다보면 규칙을 어렵지 않게 찾을 수 있다.
그런데 왜 그런 규칙이 나오는지 알 수 가 없어 검색해봤다.
아래는 이해에 도움을 준 블로그
https://jyami.tistory.com/15


## BOJ - 10844 : 쉬운 계단 수
> [key]
> - 2차원 배열을 [n+1][10] 형태로 생성, 점화식 찾기
> - dp[i][j] = dp[i-1][j-1] + dp[i-1][j+1]

1시간동안 갈피를 잡지 못해 결국 검색해서 풀었다.
직접 1~n까지 적다보면 n-1의 끝자리의 -1, +1을 하면서 경우의 수를 구해야한다는 것 까진 어떻게 이해했는데
1차원 배열로 해야한다고 생각해서 풀지를 못했다.
2차원 배열로 풀면 이전 숫자에서 나온 수로 합을 구할 수 있다는 것을 기억하면 좋을 것 같다.

## BOJ - 11057 : 오르막 수
> [key]
> - 쉬운 계단 수와 비슷한 방식의 dp를 사용하고, 점화식 찾기
> - dp[i][j] = dp[i-1][j] + dp[i][j-1]

1시간 정도 직접 규칙을 찾기위해 열심히 적어보고 어느정도 규칙이 보이긴하는데 식으로 적을 수 없었다.
식으로 만들기 위해 2차원 배열에 내가 생각하는 수를 적으면서 규칙을 찾으려고 노력했다.
결국 점화식을 찾아서 문제는 맞았는데 이 점화식이 나온 과정이 머릿속에서 뒤죽박죽 섞여서 이를 정리하려고 1시간 정도 더 쓴거같다
아래는 점화식을 찾을 때 계속 적은 패턴이다.
![2F61E8C9-78AB-4A77-87A5-C2941F6FDFE6](https://github.com/user-attachments/assets/2bf1fd12-f9be-4286-930f-2d368ff1c9af)
- n=1 : 0~9 한줄 나옴
- n=2 : 0\~9의 i에 대해 i\~9를 나타내는 줄이 나옴
- n=3 : 0\~9의 i에 대해 i\~9를 나타내는 줄의 j에 대해 j~9를 나타내는 줄이 나옴
이러한 규칙을 통해 i~9까지 j~9를 더한것을 더하는 .. 그런.. 방식이다
> 쉬운 계단 수를 풀지 않았으면 규칙이 보이더라도 아마 풀지 못했을 것 같다.
