### PR TITLE
[미정] 2024년 12월 1주차 풀이 

### DIFF
--- a/BOJ/11054. 가장 긴 바이토닉 부분 수열/qaw302_241205
+++ b/BOJ/11054. 가장 긴 바이토닉 부분 수열/qaw302_241205
@@ -1,0 +1,51 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.IOException;
+import java.util.StringTokenizer;
+import java.util.Arrays;
+
+public class Main
+{
+    public static void main(String args[]) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int[] A = new int[n+1];
+        for (int i=1; i<=n; i++) {
+            A[i] = Integer.parseInt(st.nextToken());
+        }
+        
+        
+        int[][] dp = new int[2][n+1];
+        dp[1][n] = 1;
+        
+        for (int i=1; i<=n; i++) {
+
+            //LTS
+            dp[0][i]=1;
+            for (int j=0; j<i; j++) {
+                if (A[j] < A[i]) {
+                    dp[0][i] = Math.max(dp[0][i], dp[0][j]+1);
+                }
+            }
+
+            // LDS
+            dp[1][n-i]=1;
+            for (int j=n; j>n-i; j--) {
+                 if (A[n-i] > A[j]) {
+                     dp[1][n-i] = Math.max(dp[1][n-i], dp[1][j]+1);
+                }
+            }
+        }
+
+        // LBS 결과 찾기
+        int result = 0;
+        for(int i=1; i<=n; i++) {
+            result = Math.max(result, dp[0][i]+dp[1][i] -1);
+        }
+
+        
+        System.out.println(result);
+        br.close();
+    }
+}

--- a/BOJ/1912. 연속합/qaw302_241206
+++ b/BOJ/1912. 연속합/qaw302_241206
@@ -1,0 +1,27 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.IOException;
+import java.util.StringTokenizer;
+import java.util.Arrays;
+
+public class Main {
+    public static void main(String args[]) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int[] s = new int[n];
+        for (int i=0; i<n; i++) {
+            s[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int[] dp = new int[n];
+        dp[0] = s[0];
+        for (int i=1; i<n; i++) {
+            dp[i] = Math.max(dp[i-1] + s[i], s[i]);
+        }
+
+        Arrays.sort(dp);
+        System.out.println(dp[n-1]);
+        br.close();
+    }
+}

--- a/BOJ/2579. 계단 오르기/qaw302_241206
+++ b/BOJ/2579. 계단 오르기/qaw302_241206
@@ -1,0 +1,28 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.IOException;
+
+/**
+ * 소요시간 : 21분
+ * 점화식 : dp[i] = score[i] + Math.max(score[i-1] + dp[i-3], dp[i-2]);
+ */
+public class Main {
+    public static void main(String args[]) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+
+        //점화식에서 i-3을 사용하므로 배열의 길이를 3칸 늘리고 처음 3칸을 0으로 만듬
+        int[] score = new int[n+3];
+        for (int i=3; i<n+3; i++) {
+            score[i] = Integer.parseInt(br.readLine());
+        }
+
+        int[] dp = new int[n+3];
+        for (int i=3; i<n+3; i++) {
+            dp[i] = score[i] + Math.max(score[i-1] + dp[i-3], dp[i-2]);
+        }
+
+        System.out.println(dp[n+2]);
+        br.close();
+    }
+}


### PR DESCRIPTION
## 가장 긴 바이토닉 부분 수열
> 풀이 key: 인덱스 i에서 왼쪽 LTS, 오른쪽 LDS의 합 - 1 (중복되는 i를 빼줌)

풀이를 근접하게 고민했으나 가장 바깥 for문에서 index i일때 LTS, LDS가 바로 나온다고 생각하고 풀어서 실패함.
정답에 도달하기 위해서는 일단 LTS, LDS를 다 구한 후 특정 인덱스에서 LST, LSD의 합을 추출해야하고 그 후 최댓값을 출력해야 하는 듯

문제에 적혀있는 예시만 확인하고 제출하니 몇 번 틀려서 질문 게시판에서 반례들을 찾아서 해보고 풀이를 수정함
반례 참고 링크 : https://www.acmicpc.net/board/view/108739

## 연속합
> 풀이 key: 이전의 값들과 현재 index 값을 더하면서 dp에 저장. 단 현재값 포함 더한 값이 현재값보다 작을 경우 현재 index 값을 저장

정답에 근접하게 고민했으나 머릿속에서 정리가 안돼고 헷갈려서 결국 풀이를 봄. 내가 생각한 풀이와 동일했지만 왜 이게 되는지 고민하다가 
직접 손으로 적어보니 규칙이 보였음.
항상 머릿속에 정리되지 않은 것들을 적으면서 정리해보는게 좋은 것 같다.

## 계단 오르기
> 풀이 key : 마지막 계단의 이전 계단과 전전 계단의 최댓값을 이용해서 합을 구함

이전에 풀었던 스티커문제와 비슷한 결의 문제라고 생각하며 고민하다보니 금방 규칙을 찾을 수 있었음