### PR TITLE
[미정] 2024년 12월 3주차 풀이 

### DIFF
--- a/BOJ/11052. 카드 구매하기/qaw302_241218
+++ b/BOJ/11052. 카드 구매하기/qaw302_241218
@@ -1,0 +1,33 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.IOException;
+import java.util.StringTokenizer;
+
+/** 
+ * 소요시간 : 45분
+ */
+public class Main {
+    public static void main(String args[]) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int[] p = new int[n+1];
+        for (int i=1; i<=n; i++) {
+            p[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int[] dp = new int[n+1];
+        for (int i=1; i<=n; i++) {
+            dp[i] = p[i];
+            
+            for (int j=1; j<=i/2; j++) {
+                dp[i] = Math.max(dp[i], dp[j] + dp[i-j]);
+            
+            }
+        }
+        
+        System.out.println(dp[n]);
+        br.close();
+    }
+}

--- a/BOJ/2011. 암호코드/qaw302_241217
+++ b/BOJ/2011. 암호코드/qaw302_241217
@@ -1,0 +1,38 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.IOException;
+
+public class Main{
+    public static final int MOD = 1000000;
+    public static void main(String args[]) throws IOException
+    {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String input = br.readLine();
+        int len = input.length();
+
+        int[] dp = new int[len+1];
+        dp[0] = 1;
+        dp[1] = 1;
+        if (input.startsWith("0")) {
+            dp[len] = 0;
+        } else {
+            for (int i=2; i<=len; i++) {
+                int pre = input.charAt(i-2)-'0';
+                int cur = input.charAt(i-1)-'0';
+
+                if (cur == 0) {
+                    if (pre == 1 || pre == 2) {
+                        dp[i] = dp[i-2];
+                    }
+                } else if (pre == 1 || (pre == 2 && cur <= 6)) {
+                    dp[i] = (dp[i-1] + dp[i-2]) % MOD;
+                } else {
+                    dp[i] = dp[i-1];
+                }
+            }
+        }
+        
+        System.out.println(dp[len]);
+        br.close();
+    }
+}

--- a/BOJ/2225. 합분해/qaw302_241217
+++ b/BOJ/2225. 합분해/qaw302_241217
@@ -1,0 +1,34 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.IOException;
+import java.util.StringTokenizer;
+
+/**
+ * 소요시간 : 약 1시간 30분
+ */
+public class Main
+{
+    public static void main(String args[]) throws IOException
+    {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+        int k = Integer.parseInt(st.nextToken());
+
+        if (k==1) {
+            System.out.println(1);
+        } else {
+            int[] dp = new int[n+1];
+            dp[0] = 1;
+            for (int i=0; i<k; i++) {
+                for (int j=1; j<=n; j++) {
+                    dp[j] = (dp[j-1] + dp[j]) % 1000000000;
+                }
+            }
+            System.out.println(dp[n]);
+        }
+        br.close();
+    }
+
+}


### PR DESCRIPTION
## 합분해
![스크린샷 2024-12-18 오전 10 25 55](https://github.com/user-attachments/assets/7d0d89e3-a0d3-4400-a1b4-e56ba4b30728)
> key: dp[i] = dp[i-1] + dp[i] (k번 반복)
k가 증가할때 마다 k-i의 횟수를 기반으로 값이 증가하는 패턴이다
이차원으로 할 수 도 있겠지만 이 문제에서는 1차원으로 갱신(누적)하는 방식이 좋지 않을까 생각한다.

## 암호코드
> key: 현재와 이전 수가 0일 때를 잘 고려해서 처리해줘야함

원래는 dp[i] = (이전숫자 * 10 + 현재숫자) > 26 ? dp[i-1] : dp[i-1] + dp[i-2]
이렇게 해서 테스트 코드가 잘 돌아갔었다.
풀면서 3가지 문제가 있었다. . 

1. 과도한 split 메서드 사용으로 메모리 초과
    - 단순 메서드만 사용하는 건 메모리 사용을 안 한다고 생각했는데 split 메서드를 사용할때마다 생긴다는 것을 이번에 깨달았다.. 
   
3. 현재가 0
    - 현재가 0일 때 2가지 경우가 있음
    1. 이전이 1, 2 -> dp[i] = dp[i-2]
    2. 이전이 0, 3이상  -> 0 (처리 안함)
 
5. 현재가 0이 아님
    1. 이전이 값이 1 -> dp[i] = dp[i-1] + dp[i-2]
    2. 이전 값이 2 -> 현재 값이 6 이하 -> dp[i] = dp[i-1] + dp[i-2]
    3. 이전 값이 0 또는 3이상 -> dp[i] = dp[i-1]

여러 글을 읽어도 이해가 안돼서 한참 봤다. .  아래는 그나마 이해에 도움을 준 블로그
참고 : https://tussle.tistory.com/1137

## 카드 구매하기
> key: dp[n] = MAX(dp[i] + dp[n-i])

n-i개일때의 최대비용과 i개 일때의 최대비용의 합 중 큰 값을 구하는 식
ex) n=4 일때 1개+3개, 2개+2개 조합 중 비용 최댓값을 구함